### PR TITLE
update runId

### DIFF
--- a/dist/lib/reporter.js
+++ b/dist/lib/reporter.js
@@ -34,7 +34,7 @@ class TestRailReporter extends reporter_1.default {
     onSuiteStart() {
         return __awaiter(this, void 0, void 0, function* () {
             const lastRun = yield this.client.getLastTestRun(this.options.projectId, this.options.suiteId);
-            this.runId = lastRun[0].id;
+            this.runId = lastRun.runs[0].id;
         });
     }
     onTestPass(test) {

--- a/src/lib/reporter.ts
+++ b/src/lib/reporter.ts
@@ -36,7 +36,7 @@ class TestRailReporter extends WDIOReporter {
 
   async onSuiteStart() {
     const lastRun = await this.client.getLastTestRun(this.options.projectId, this.options.suiteId);
-    this.runId = lastRun[0].id;
+    this.runId = lastRun.runs[0].id;
   }
 
   onTestPass(test) {


### PR DESCRIPTION
Response data for `getLastTestRun` was 
```
{
  offset: 0,
  limit: 1,
  size: 1,
  _links: {
    next: '/api/v2/get_runs/1&suite_id=1&limit=1&offset=1',
    prev: null
  },
  runs: [
    {
      id: 180,
      suite_id: 1,
      name: 'Test Run 7/13/2022',
      description: null,
      milestone_id: null,
      assignedto_id: null,
      include_all: true,
      is_completed: false,
      completed_on: null,
      config: null,
      config_ids: [],
      passed_count: 0,
      blocked_count: 0,
      untested_count: 1,
      retest_count: 0,
      failed_count: 0,
      custom_status1_count: 0,
      custom_status2_count: 0,
      custom_status3_count: 0,
      custom_status4_count: 0,
      custom_status5_count: 0,
      custom_status6_count: 0,
      custom_status7_count: 0,
      project_id: 1,
      plan_id: null,
      created_on: 1657754230,
      updated_on: 1657754230,
      refs: null,
      created_by: 1,
      url: 'http://url.io'
    }
  ]
}
```